### PR TITLE
2025年度のページ作成・Austin Myers氏のトークの情報を追加

### DIFF
--- a/2023/index.html
+++ b/2023/index.html
@@ -480,7 +480,7 @@
     </div>
 </div>
 <p style="height: 24px">
-<a href="/"><<2024年の講演はこちら</a><a class="float-right" href="/2022">2022年の講演はこちら>></a>
+<a href="/2024"><<2024年の講演はこちら</a><a class="float-right" href="/2022">2022年の講演はこちら>></a>
 </p>
 
 

--- a/2024/index.html
+++ b/2024/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>KUIST Colloquium 
+2024
+</title>
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+        <link rel="stylesheet" href="/style.css">
+    </head>
+    <body>
+        <header style="background: #00205B;">
+            <img src="/C-EL-W.svg" height=45 style="margin: 1em 0em 0em 1em;">
+            <h1 style="color: #FFF; text-align: center; font-family: serif; font-size:3em; padding: 0.4em;">
+                IST COLLOQUIUM 
+2024
+
+            </h1>
+        </header>
+        <section class="section">
+            <div class="container">
+                
+<div class="card" style="width: min(90%, 1200); margin: 50px; margin-left: auto; margin-right: auto; display: block;">
+    <div class="card-body" style="overflow:hidden">
+        
+        <h2 style="border-bottom: solid; margin-bottom:20px; padding-bottom:2px; border-color:#00205B;"><b>Distinguishing Serial from Parallel Confidence Processing</b></h2>
+        
+        
+        <div style="float:right; width: max(25%, 130px);">
+        <img src=".&#x2F;pascal_mamassian_cropped.png" alt="講演者の画像" style="width:100%; padding: 0px 0px 10px 10px;">
+        </div>
+        
+        <h3 class="card-title" style="margin-bottom: 6px;">
+            <b>Pascal Mamassian</b>
+        
+            <span style="font-size: 1.25rem"><a href="https:&#x2F;&#x2F;lsp.dec.ens.fr&#x2F;en&#x2F;member&#x2F;647&#x2F;pascal-mamassian">🌐</a></span>
+        
+        </h3>
+        <h5 class="card-text" style="margin-bottom: 22px;">CNRS Director of Research, Head of LSP (Laboratoire des systemes perceptifs) Centre national de la recherche scientifique (CNRS) and Ecole Normale Supérieure, Paris, France</h5>
+        
+        <details style="margin-bottom: 22px">
+        <summary>講演者経歴</summary>
+        Pascal Mamassian was born in Lyon (France) and was trained in Telecommunication Engineering (Sup' Télécom, Paris, France). He then obtained a Masters in Cognitive Sciences (Univ. Paris 6 & EHESS, Paris, France) and a PhD in Experimental and Biological Psychology (Univ. of Minnesota, Minneapolis, USA). He has worked at the Max-Planck Institute for Biological Cybernetics (Tübingen, Germany) and New York University (New York, USA). He was at the University of Glasgow (Glasgow, UK) as lecturer and then senior lecturer before taking a researcher position at the CNRS (France).
+        </details>
+        
+        <p, class="card-text">
+        <b>日時</b>：4月12日（金） 
+         13:15〜14:30 
+        </p>
+        
+        <p class="card-text">
+        <b>場所</b>：総合研究12号館003講義室（地階）
+        </p>
+        
+        
+        <p class="card-text">Visual confidence refers to our ability to predict the correctness of our perceptual decisions. Knowing the limits of this ability, both in terms of biases (e.g. overconfidence) and sensitivity (e.g. blindsight), is clearly important to approach a full picture of perceptual decision making. In recent years, we have explored visual confidence using a paradigm called confidence forced-choice. In this paradigm, observers have to choose which of two perceptual decisions is more likely to be correct. I will review some behavioural results obtained with the confidence forced-choice paradigm, together with a theoretical model based on signal detection theory. In particular, I will argue that the confidence forced-choice paradigm offers the possibility to distinguish serial from parallel confidence processing. Finally, I will present an extension of the theoretical model for experiments using confidence ratings, and discuss the conditions under which serial and parallel confidence processing can be distiguished using this latter paradigm.</p>
+        
+        
+            
+        
+    </div>
+</div>
+<p style="height: 24px">
+<a class="float-right" href="/2023">2023年の講演はこちら>></a>
+</p>
+
+
+            </div>
+        </section>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    </body>
+</html>

--- a/2024/index.html
+++ b/2024/index.html
@@ -62,7 +62,7 @@
     </div>
 </div>
 <p style="height: 24px">
-<a class="float-right" href="/2023">2023年の講演はこちら>></a>
+<a href="/"><<2025年の講演はこちら</a><a class="float-right" href="/2023">2023年の講演はこちら>></a>
 </p>
 
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>KUIST Colloquium 
-2024
+2025
 </title>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
         <link rel="stylesheet" href="/style.css">
@@ -24,37 +24,37 @@
 <div class="card" style="width: min(90%, 1200); margin: 50px; margin-left: auto; margin-right: auto; display: block;">
     <div class="card-body" style="overflow:hidden">
         
-        <h2 style="border-bottom: solid; margin-bottom:20px; padding-bottom:2px; border-color:#00205B;"><b>Distinguishing Serial from Parallel Confidence Processing</b></h2>
+        <h2 style="border-bottom: solid; margin-bottom:20px; padding-bottom:2px; border-color:#00205B;"><b>Vision at Work: Reflections on Real-World Computer Vision from Robots to Video Understanding and Back</b></h2>
         
         
         <div style="float:right; width: max(25%, 130px);">
-        <img src=".&#x2F;pascal_mamassian_cropped.png" alt="講演者の画像" style="width:100%; padding: 0px 0px 10px 10px;">
+        <!-- <img src=".&#x2F;pascal_mamassian_cropped.png" alt="講演者の画像" style="width:100%; padding: 0px 0px 10px 10px;"> -->
         </div>
         
         <h3 class="card-title" style="margin-bottom: 6px;">
-            <b>Pascal Mamassian</b>
+            <b>Austin Myers</b>
         
-            <span style="font-size: 1.25rem"><a href="https:&#x2F;&#x2F;lsp.dec.ens.fr&#x2F;en&#x2F;member&#x2F;647&#x2F;pascal-mamassian">🌐</a></span>
+            <!--<span style="font-size: 1.25rem"><a href="https:&#x2F;&#x2F;lsp.dec.ens.fr&#x2F;en&#x2F;member&#x2F;647&#x2F;pascal-mamassian">🌐</a></span> -->
         
         </h3>
-        <h5 class="card-text" style="margin-bottom: 22px;">CNRS Director of Research, Head of LSP (Laboratoire des systemes perceptifs) Centre national de la recherche scientifique (CNRS) and Ecole Normale Supérieure, Paris, France</h5>
+        <h5 class="card-text" style="margin-bottom: 22px;">Agility Robotics</h5>
         
         <details style="margin-bottom: 22px">
         <summary>講演者経歴</summary>
-        Pascal Mamassian was born in Lyon (France) and was trained in Telecommunication Engineering (Sup' Télécom, Paris, France). He then obtained a Masters in Cognitive Sciences (Univ. Paris 6 & EHESS, Paris, France) and a PhD in Experimental and Biological Psychology (Univ. of Minnesota, Minneapolis, USA). He has worked at the Max-Planck Institute for Biological Cybernetics (Tübingen, Germany) and New York University (New York, USA). He was at the University of Glasgow (Glasgow, UK) as lecturer and then senior lecturer before taking a researcher position at the CNRS (France).
+        Austin Myers is a research engineer currently working on embodied perception at Agility Robotics. His career has spanned academia and industry, with roles at Waymo, Google Research, and DeepMind, where he developed vision systems for robot manipulation, self-driving vehicles, and large-scale video understanding. Austin received his PhD from the University of Maryland, focusing on understanding the affordances of object parts through geometric reasoning. His broad research interests lie at the intersection of joint video and language representation learning, large multimodal models, and embodied perception for everyday robots.
         </details>
         
         <p, class="card-text">
-        <b>日時</b>：4月12日（金） 
-         13:15〜14:30 
+        <b>日時</b>：7月7日（月） 
+         13:15〜14:45 
         </p>
         
         <p class="card-text">
-        <b>場所</b>：総合研究12号館003講義室（地階）
+        <b>場所</b>：総合研究7号館1階セミナー室1
         </p>
         
         
-        <p class="card-text">Visual confidence refers to our ability to predict the correctness of our perceptual decisions. Knowing the limits of this ability, both in terms of biases (e.g. overconfidence) and sensitivity (e.g. blindsight), is clearly important to approach a full picture of perceptual decision making. In recent years, we have explored visual confidence using a paradigm called confidence forced-choice. In this paradigm, observers have to choose which of two perceptual decisions is more likely to be correct. I will review some behavioural results obtained with the confidence forced-choice paradigm, together with a theoretical model based on signal detection theory. In particular, I will argue that the confidence forced-choice paradigm offers the possibility to distinguish serial from parallel confidence processing. Finally, I will present an extension of the theoretical model for experiments using confidence ratings, and discuss the conditions under which serial and parallel confidence processing can be distiguished using this latter paradigm.</p>
+        <p class="card-text">Over the past decade, I’ve worked on perception systems spanning everyday robot manipulation, self-driving cars, and large-scale video understanding across academia and industry labs like Waymo, Google Research, DeepMind, and now Agility Robotics. In this talk, I’ll share perspectives on developments in the field and industry, and lessons from deploying computer vision systems in the real world. I’ll tell you why construction cones are harder than they look, what it takes to build vision-language models that understand YouTube videos without human supervision, how to transfer fundamental research to products that touch billions of users, and I’ll revisit how we once tried to enable robots to use tools they had never seen before—and how we've come back full circle with new tools at our disposal in my work at Agility Robotics. Beyond the research itself, I’ll reflect on navigating careers between academia and industry, choosing impactful problems, and the exciting challenges ahead in embodied AI.</p>
         
         
             

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,9 @@
         <loc>https:kuist-colloquium.github.io/2023/</loc>
     </url>
     <url>
+        <loc>https:kuist-colloquium.github.io/2024/</loc>
+    </url>
+    <url>
         <loc>https:kuist-colloquium.github.io/test/</loc>
     </url>
     <url>


### PR DESCRIPTION
1. 2024年度のページを作成 244bd9b
2. 2023年度のページ・2024年度のページのリンクを修正 5de771d
3. 2025年度のページを作成・Austin Myers氏のトークの情報を追加 908eff6

TODO: 講演者のホームページ・画像を追加